### PR TITLE
Add Socket Time Out

### DIFF
--- a/src/main/java/low/citory/util/PacketUtil.java
+++ b/src/main/java/low/citory/util/PacketUtil.java
@@ -61,6 +61,7 @@ public final class PacketUtil {
 	public static List<Object> getDatIO(Socket socket, String serverIP, int serverPORT) throws IOException {
 		long currentTime = System.currentTimeMillis();
 		socket.connect(new InetSocketAddress(serverIP, serverPORT), 5000);
+		socket.setSoTimeout(5000);
 		long ping = System.currentTimeMillis() - currentTime;
 
 		DataInputStream inputStream = new DataInputStream(socket.getInputStream());


### PR DESCRIPTION
The `5000` in `connect(address, 5000)` sets a 5-second timeout for establishing the connection, preventing the program from hanging during connection attempts.  
`setSoTimeout(5000)` sets a 5-second timeout for reading data, ensuring the input stream doesn't block indefinitely.  